### PR TITLE
correct sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ dist
 
 # TernJS port file
 .tern-port
+
+index.html

--- a/index.js
+++ b/index.js
@@ -56,7 +56,11 @@ files.forEach((file) => {
 })
 
 
+outputFiles.sort((a, b) => {
+  return a.order - b.order;
+})
 console.log(outputFiles)
+
 
 const output = `<html>
 <head>


### PR DESCRIPTION
@emjun i think we would want to sort still in case the filesystem doesn't return the images in numeric order. This corrects the direction and moves the log statement after the sort occurs so the reporting is accurate. 

Also a small update to `.gitignore` to avoid checking in generated index.html files. 